### PR TITLE
Remove iterator test ignores

### DIFF
--- a/src/commonTest/kotlin/com/jakewharton/platformcollections/PlatformListTest.kt
+++ b/src/commonTest/kotlin/com/jakewharton/platformcollections/PlatformListTest.kt
@@ -231,7 +231,6 @@ class PlatformListTest {
 		assertEquals("one", list[0])
 	}
 
-	@DarwinIgnore // Objective-C's exceptions cannot be caught.
 	@Test fun iteratorRemoveBeforeNextThrows() {
 		val list = PlatformList<String>()
 		list.add("one")
@@ -244,7 +243,6 @@ class PlatformListTest {
 		assertEquals(2, list.size)
 	}
 
-	@DarwinIgnore // Objective-C's exceptions cannot be caught.
 	@Test fun iteratorRemoveTwiceThrows() {
 		val list = PlatformList<String>()
 		list.add("one")
@@ -259,7 +257,6 @@ class PlatformListTest {
 		assertEquals(1, list.size)
 	}
 
-	@DarwinIgnore // Objective-C's exceptions cannot be caught.
 	@Test fun iteratorRemoveAfterHasNextThrows() {
 		val list = PlatformList<String>()
 		list.add("one")

--- a/src/commonTest/kotlin/com/jakewharton/platformcollections/PlatformMapTest.kt
+++ b/src/commonTest/kotlin/com/jakewharton/platformcollections/PlatformMapTest.kt
@@ -253,7 +253,6 @@ class PlatformMapTest {
 		assertTrue("one" in map)
 	}
 
-	@DarwinIgnore // Objective-C's exceptions cannot be caught.
 	@Test fun iteratorRemoveBeforeNextThrows() {
 		val map = PlatformMap<String, String>()
 		map.put("one", "two")
@@ -266,7 +265,6 @@ class PlatformMapTest {
 		assertEquals(2, map.size)
 	}
 
-	@DarwinIgnore // Objective-C's exceptions cannot be caught.
 	@Test fun iteratorRemoveTwiceThrows() {
 		val map = PlatformMap<String, String>()
 		map.put("one", "two")
@@ -281,7 +279,6 @@ class PlatformMapTest {
 		assertEquals(1, map.size)
 	}
 
-	@DarwinIgnore // Objective-C's exceptions cannot be caught.
 	@Test fun iteratorRemoveAfterHasNextThrows() {
 		val map = PlatformMap<String, String>()
 		map.put("one", "two")

--- a/src/commonTest/kotlin/com/jakewharton/platformcollections/PlatformSetTest.kt
+++ b/src/commonTest/kotlin/com/jakewharton/platformcollections/PlatformSetTest.kt
@@ -155,7 +155,6 @@ class PlatformSetTest {
 		assertTrue("one" in set)
 	}
 
-	@DarwinIgnore // Objective-C's exceptions cannot be caught.
 	@Test fun iteratorRemoveBeforeNextThrows() {
 		val set = PlatformSet<String>()
 		set.add("one")
@@ -168,7 +167,6 @@ class PlatformSetTest {
 		assertEquals(2, set.size)
 	}
 
-	@DarwinIgnore // Objective-C's exceptions cannot be caught.
 	@Test fun iteratorRemoveTwiceThrows() {
 		val set = PlatformSet<String>()
 		set.add("one")
@@ -183,7 +181,6 @@ class PlatformSetTest {
 		assertEquals(1, set.size)
 	}
 
-	@DarwinIgnore // Objective-C's exceptions cannot be caught.
 	@Test fun iteratorRemoveAfterHasNextThrows() {
 		val set = PlatformSet<String>()
 		set.add("one")


### PR DESCRIPTION
These exceptions originate from Kotlin, not Darwin.